### PR TITLE
Add pinned tasklist toggle

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -216,8 +216,11 @@ export async function updateSessionName(sessionId, name) {
  * @param {string} sessionId - The ID of the session to clear.
  * @returns {Promise<object>} The response data.
  */
-export async function clearSessionMessages(sessionId) {
-    const response = await fetch(`/api/sessions/${sessionId}/clear`, {
+export async function clearSessionMessages(sessionId, { preserveTasks = false } = {}) {
+    const url = preserveTasks
+        ? `/api/sessions/${sessionId}/clear?preserveTasks=true`
+        : `/api/sessions/${sessionId}/clear`;
+    const response = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' }
     });

--- a/public/js/task-tracker-widget.js
+++ b/public/js/task-tracker-widget.js
@@ -748,6 +748,12 @@ var TaskTrackerWidget = class _TaskTrackerWidget extends i4 {
       background-color: var(--accent-primary);
     }
 
+    .ai-task-controls {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
     /* Content */
     .ai-tasks-content {
       background: var(--secondary-bg);
@@ -883,6 +889,7 @@ var TaskTrackerWidget = class _TaskTrackerWidget extends i4 {
   `;
     // ------------------ state ------------------
     tasks = [];
+    pinned = false;
     /**
      * For hierarchical mode: tasks is an array of root tasks, each may have children:[] recursively.
      * We keep a flat map for FLIP animation and direct id lookups (for add/remove/edit).
@@ -1105,6 +1112,11 @@ var TaskTrackerWidget = class _TaskTrackerWidget extends i4 {
         return [...this.tasks];
     }
 
+    togglePin() {
+        this.pinned = !this.pinned;
+        this.requestUpdate();
+    }
+
     /**
      * Sets the entire task list directly, bypassing the animation queue.
      * This provides an immediate, non-animated update to the displayed tasks.
@@ -1191,7 +1203,12 @@ var TaskTrackerWidget = class _TaskTrackerWidget extends i4 {
             ${this._icon("pending", true)}
             Tasks
           </div>
-          <span class="ai-task-counter">${completed}/${total} completed</span>
+          <div class="ai-task-controls">
+            <span class="ai-task-counter">${completed}/${total} completed</span>
+            <button class="secondary-button icon-button" title="Toggle Pin" @click=${() => this.togglePin()}>
+              <span class="material-icons" style=${this.pinned ? '' : 'transform: rotate(45deg);'}>push_pin</span>
+            </button>
+          </div>
         </header>
         <div class="ai-tasks-content">
           <ul class="ai-task-list">

--- a/public/js/ui/chat.js
+++ b/public/js/ui/chat.js
@@ -25,6 +25,7 @@ const stopButton = document.getElementById('stop-button');
 const attachmentButton = document.getElementById('attachment-button');
 const fileInput = document.getElementById('file-input');
 const attachedFilename = document.getElementById('attached-filename');
+const taskTracker = document.getElementById('tracker');
 
 // Variable to store pending image data and the prompt editor instance
 let pendingImageDataUrl = null;
@@ -106,7 +107,8 @@ export function initChatForm() {
                 
                 try {
                     setStatus('thinking', `Clearing session ${sessionName}...`);
-                    await api.clearSessionMessages(sessionId);
+                    const preserveTasks = taskTracker && taskTracker.pinned;
+                    await api.clearSessionMessages(sessionId, { preserveTasks });
                     
                     console.log(`Reloading current session ${sessionId} after clear.`);
                     setStatus('connecting', 'Reloading session...');

--- a/src/routes/projectsRoutes.js
+++ b/src/routes/projectsRoutes.js
@@ -199,12 +199,14 @@ import {getSystemAndContext} from "../services/agent/index.js"; // Import manage
 routerSessions.post('/:id/clear', async (req, res) => {
   try {
     const { id: sessionId } = req.params;
+    const preserveTasks = req.query.preserveTasks === 'true';
     console.log(`Attempting to clear session: ${sessionId}`);
 
     let existingWorkingDirectory = null;
     let existingAgentId = null;
     let existingMcpAlias = null;
     let existingMcpUrl = null;
+    let existingTasks = [];
 
     // 1. Try to get the *current* working directory, agentId, and MCP data (handle potential legacy fields)
     try {
@@ -216,6 +218,7 @@ routerSessions.post('/:id/clear', async (req, res) => {
       existingAgentId = existingRawData?.[FIELD_NAMES.AGENT_ID] || null;
       existingMcpAlias = existingRawData?.[FIELD_NAMES.MCP_ALIAS] || null;
       existingMcpUrl = existingRawData?.[FIELD_NAMES.MCP_URL] || null;
+      existingTasks = existingRawData?.[FIELD_NAMES.TASKS] || [];
 
       console.log(`Found existing working directory for session ${sessionId}: ${existingWorkingDirectory}`);
       console.log(`Found existing agent ID for session ${sessionId}: ${existingAgentId}`);
@@ -238,6 +241,7 @@ routerSessions.post('/:id/clear', async (req, res) => {
       [FIELD_NAMES.AGENT_ID]: existingAgentId, // Preserve the found agent ID
       [FIELD_NAMES.MCP_ALIAS]: existingMcpAlias, // Preserve the found MCP alias
       [FIELD_NAMES.MCP_URL]: existingMcpUrl, // Preserve the found MCP URL
+      ...(preserveTasks ? { [FIELD_NAMES.TASKS]: existingTasks } : {}),
       // updatedAt will be added by setSessionData/saveSession
     };
 


### PR DESCRIPTION
## Summary
- extend clear endpoint with `preserveTasks` query to optionally keep tasks
- allow API `clearSessionMessages` to pass `preserveTasks`
- respect task pinning when clearing chat
- implement pin toggle button in task list widget

## Testing
- `npm test` *(fails: Cannot find module tests/fileSystemTools.test.js)*
- `npm run test:grep` *(fails: ERR_MODULE_NOT_FOUND about glob)*
