### PR TITLE
Persist task pin state

### DIFF
--- a/public/js/socket.js
+++ b/public/js/socket.js
@@ -189,6 +189,7 @@ export function setupSocketEventHandlers(socket) {
                 setTimeout(() => {
                     tracker.setTasks(formattedTasks);
                 }, 0);
+                tracker.pinned = !!data.tasksPinned;
 
                 console.log("Initial tasks populated.");
             }
@@ -769,5 +770,15 @@ export function emitSetMcp(socket, mcpAlias, mcpUrl) {
         socket.emit('set_mcp', { mcpAlias, mcpUrl });
     } else {
         console.error("Cannot emit set_mcp: socket not connected.");
+    }
+}
+
+/** Emits 'set_tasks_pinned' */
+export function emitSetTasksPinned(socket, pinned) {
+    if (socket?.connected) {
+        console.log(`Emitting set_tasks_pinned: ${pinned}`);
+        socket.emit('set_tasks_pinned', { pinned });
+    } else {
+        console.error("Cannot emit set_tasks_pinned: socket not connected.");
     }
 }

--- a/public/js/task-tracker-widget.js
+++ b/public/js/task-tracker-widget.js
@@ -1,3 +1,5 @@
+import { appState } from './state.js';
+import { emitSetTasksPinned } from './socket.js';
 // node_modules/@lit/reactive-element/css-tag.js
 var t = globalThis;
 var e = t.ShadowRoot && (void 0 === t.ShadyCSS || t.ShadyCSS.nativeShadow) && "adoptedStyleSheets" in Document.prototype && "replace" in CSSStyleSheet.prototype;
@@ -1164,6 +1166,10 @@ var TaskTrackerWidget = class _TaskTrackerWidget extends i4 {
 
     togglePin() {
         this.pinned = !this.pinned;
+
+        if (appState.socket) {
+            emitSetTasksPinned(appState.socket, this.pinned);
+        }
         
         // Since we're now using CSS classes for pinned state,
         // we only need to request an update to apply the class change.

--- a/src/routes/projectsRoutes.js
+++ b/src/routes/projectsRoutes.js
@@ -207,6 +207,7 @@ routerSessions.post('/:id/clear', async (req, res) => {
     let existingMcpAlias = null;
     let existingMcpUrl = null;
     let existingTasks = [];
+    let existingTasksPinned = false;
 
     // 1. Try to get the *current* working directory, agentId, and MCP data (handle potential legacy fields)
     try {
@@ -219,6 +220,7 @@ routerSessions.post('/:id/clear', async (req, res) => {
       existingMcpAlias = existingRawData?.[FIELD_NAMES.MCP_ALIAS] || null;
       existingMcpUrl = existingRawData?.[FIELD_NAMES.MCP_URL] || null;
       existingTasks = existingRawData?.[FIELD_NAMES.TASKS] || [];
+      existingTasksPinned = !!existingRawData?.[FIELD_NAMES.TASKS_PINNED];
 
       console.log(`Found existing working directory for session ${sessionId}: ${existingWorkingDirectory}`);
       console.log(`Found existing agent ID for session ${sessionId}: ${existingAgentId}`);
@@ -242,6 +244,7 @@ routerSessions.post('/:id/clear', async (req, res) => {
       [FIELD_NAMES.MCP_ALIAS]: existingMcpAlias, // Preserve the found MCP alias
       [FIELD_NAMES.MCP_URL]: existingMcpUrl, // Preserve the found MCP URL
       ...(preserveTasks ? { [FIELD_NAMES.TASKS]: existingTasks } : {}),
+      [FIELD_NAMES.TASKS_PINNED]: existingTasksPinned,
       // updatedAt will be added by setSessionData/saveSession
     };
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -468,6 +468,7 @@ io.on('connection', (socket) => {
                 mcpAlias: sessionData.mcpAlias,
                 mcpUrl: sessionData.mcpUrl,
                 toolLogs: sessionData.toolLogs || [],
+                tasksPinned: sessionData.tasksPinned || false,
                 agentState: sessionData.agentState || {
                     status: 'idle',
                     statusText: null,
@@ -761,6 +762,22 @@ io.on('connection', (socket) => {
 
         } catch (error) {
             console.error('Error setting MCP:', error);
+        }
+    });
+
+    // Handle task pinned state
+    socket.on('set_tasks_pinned', async (data) => {
+        try {
+            const { pinned } = data;
+            const sessionId = socket.userData.currentSessionId;
+            if (!sessionId) {
+                console.warn('Attempted to set tasks pinned with no active session');
+                return;
+            }
+            await projectSessionManager.setTasksPinned(sessionId, pinned);
+            console.log(`Set tasks pinned for session ${sessionId}: ${pinned}`);
+        } catch (error) {
+            console.error('Error setting tasks pinned state:', error);
         }
     });
     

--- a/src/services/sessions/index.js
+++ b/src/services/sessions/index.js
@@ -110,6 +110,11 @@ class ProjectSessionManager {
         // 4. Preserve Tasks
         normalized[FIELD_NAMES.TASKS] = Array.isArray(rawData[FIELD_NAMES.TASKS]) ? rawData[FIELD_NAMES.TASKS] : [];
 
+        // 4.1 Preserve task pinned state
+        normalized[FIELD_NAMES.TASKS_PINNED] = typeof rawData[FIELD_NAMES.TASKS_PINNED] === 'boolean'
+            ? rawData[FIELD_NAMES.TASKS_PINNED]
+            : false;
+
         // 5. Preserve Tool Logs (Handle legacy 'logs' if necessary - verify usage)
         const toolLogs = rawData[FIELD_NAMES.TOOL_LOGS] || rawData[FIELD_NAMES.LEGACY_LOGS]; // Check if 'logs' was used
         normalized[FIELD_NAMES.TOOL_LOGS] = Array.isArray(toolLogs) ? toolLogs : [];
@@ -620,6 +625,27 @@ class ProjectSessionManager {
         sessionData[FIELD_NAMES.MCP_ALIAS] = mcpAlias;
         sessionData[FIELD_NAMES.MCP_URL] = mcpUrl;
         await this.saveSession(sessionId);
+    }
+
+    /**
+     * Set whether the task panel is pinned
+     * @param {string} sessionId
+     * @param {boolean} pinned
+     */
+    async setTasksPinned(sessionId, pinned) {
+        const sessionData = await this.getSession(sessionId);
+        sessionData[FIELD_NAMES.TASKS_PINNED] = !!pinned;
+        await this.saveSession(sessionId);
+    }
+
+    /**
+     * Get pinned state for tasks
+     * @param {string} sessionId
+     * @returns {Promise<boolean>}
+     */
+    async getTasksPinned(sessionId) {
+        const sessionData = await this.getSession(sessionId);
+        return !!sessionData[FIELD_NAMES.TASKS_PINNED];
     }
 
     /**

--- a/src/services/sessions/schema.js
+++ b/src/services/sessions/schema.js
@@ -11,6 +11,7 @@ export const FIELD_NAMES = Object.freeze({
     HISTORY: 'history',                   // Canonical name for chat message history (replaces 'conversation')
     ACCOUNTING: 'accounting',             // Canonical name for usage/cost tracking (replaces 'accountingData')
     TASKS: 'tasks',                       // Canonical name for the list of tasks
+    TASKS_PINNED: 'tasksPinned',         // Tracks whether task panel is pinned
     
     TOOL_LOGS: 'toolLogs',                // Canonical name for tool execution logs
     AGENT_STATE: 'agentState',            // Canonical name for the agent's current operational state
@@ -34,6 +35,7 @@ export const DEFAULT_SESSION_DATA = Object.freeze({
     [FIELD_NAMES.HISTORY]: [],
     [FIELD_NAMES.ACCOUNTING]: { models: {}, totalUSD: 0 },
     [FIELD_NAMES.TASKS]: [],
+    [FIELD_NAMES.TASKS_PINNED]: false,
     [FIELD_NAMES.TOOL_LOGS]: [],
     [FIELD_NAMES.AGENT_STATE]: {
         status: 'idle',


### PR DESCRIPTION
## Summary
- add `tasksPinned` field to session schema
- keep pin state when normalising sessions
- expose `setTasksPinned`/`getTasksPinned` helpers
- send pinned state with `session_joined`
- allow clients to update pinned state via socket
- preserve pin state on session clear
- update front-end to emit and apply pin state

## Testing
- `npm test` *(fails: Cannot find module '/workspace/localforge/tests/fileSystemTools.test.js')*